### PR TITLE
Fix 2FA login configuration

### DIFF
--- a/Settlex/settings.py
+++ b/Settlex/settings.py
@@ -127,8 +127,8 @@ AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
 ]
 
-# Avoid reverse_lazy here, just use the resolved path
-LOGIN_URL = "/account/login/"
+# Use the custom two-factor login view
+LOGIN_URL = reverse_lazy("two_factor_login")
 LOGIN_REDIRECT_URL = reverse_lazy("settlements_app:my_settlements")
 LOGOUT_REDIRECT_URL = reverse_lazy("settlements_app:home")
 

--- a/settlements_app/context_processors.py
+++ b/settlements_app/context_processors.py
@@ -6,6 +6,7 @@ def chat_visibility(request):
 
     # Paths or prefixes where chat should be disabled
     excluded_prefixes = [
+        "/login/",
         "/account/login/",
         "/account/two_factor/",
         "/two_factor/",  # Catch any two_factor views


### PR DESCRIPTION
## Summary
- use proper login URL for two-factor authentication
- hide chat widget on the login page as well

## Testing
- `python manage.py check`
- `flake8 settlements_app Settlex`

------
https://chatgpt.com/codex/tasks/task_e_6841ec9fa49c8329943af5c81179d906