### PR TITLE
Fix two_factor middleware usage

### DIFF
--- a/Settlex/middleware/enforce_2fa.py
+++ b/Settlex/middleware/enforce_2fa.py
@@ -11,11 +11,11 @@ class Enforce2FAMiddleware:
         if request.user.is_authenticated and not request.user.is_staff:
             if not default_device(request.user):
                 safe_paths = [
-                    reverse('two_factor:login'),
-                    reverse('two_factor:setup'),
+                    reverse('two_factor_login'),
+                    reverse('two_factor_setup'),
                     reverse('settlements_app:logout'),  # Ensure 'settlements_app:logout' is used
                 ]
                 if not any(request.path.startswith(path) for path in safe_paths):
-                    return redirect('two_factor:setup')
+                    return redirect('two_factor_setup')
 
         return self.get_response(request)


### PR DESCRIPTION
## Summary
- update 2FA middleware to use custom setup/login route names
- redirect to custom setup view when 2FA is missing
- verify Django server starts

## Testing
- `python manage.py check`
- `python manage.py runserver 0:8000` *(stopped with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68463377c090832988f27bfef32b5aa3