### PR TITLE
Add custom 2FA views to namespace

### DIFF
--- a/Settlex/urls.py
+++ b/Settlex/urls.py
@@ -4,20 +4,32 @@ from two_factor import urls as tf_urls
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib.auth import views as auth_views
-from settlements_app.views import SettlexTwoFactorLoginView, SettlexTwoFactorSetupView
+from settlements_app.views import (
+    SettlexTwoFactorLoginView,
+    SettlexTwoFactorSetupView,
+)
+
+settlex_two_factor_patterns = [
+    path("login/", SettlexTwoFactorLoginView.as_view(), name="login"),
+    path("setup/", SettlexTwoFactorSetupView.as_view(), name="setup"),
+]
 
 urlpatterns = [
     path("admin/login/", auth_views.LoginView.as_view(template_name="admin/login.html"), name="admin_login"),
     path("admin/", admin.site.urls),
-
-    # 🔐 Custom 2FA views
-    path("login/", SettlexTwoFactorLoginView.as_view(), name="two_factor_login"),
-    path("two_factor/setup/", SettlexTwoFactorSetupView.as_view(), name="two_factor_setup"),
-
     # ✅ This must come **before** your app's urls to register the namespace and avoid overrides
     path(
         "two_factor/",
-        include((tf_urls.core + tf_urls.profile + tf_urls.plugin_urlpatterns, "two_factor"), namespace="two_factor"),
+        include(
+            (
+                settlex_two_factor_patterns
+                + tf_urls.core
+                + tf_urls.profile
+                + tf_urls.plugin_urlpatterns,
+                "two_factor",
+            ),
+            namespace="two_factor",
+        ),
     ),
 
     # 🧾 Include your app routes last


### PR DESCRIPTION
## Summary
- integrate custom two-factor login & setup views within the `two_factor` namespace

## Testing
- `python manage.py check`
- `flake8` *(fails: E501 line too long, unused imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684635dae46083298764d7b56214d6fe