### PR TITLE
Fix URL reversing in 2FA middleware

### DIFF
--- a/Settlex/middleware/enforce_2fa.py
+++ b/Settlex/middleware/enforce_2fa.py
@@ -11,11 +11,15 @@ class Enforce2FAMiddleware:
         if request.user.is_authenticated and not request.user.is_staff:
             if not default_device(request.user):
                 safe_paths = [
-                    reverse('two_factor:login'),
-                    reverse('two_factor:setup'),
-                    reverse('settlements_app:logout'),  # Ensure 'settlements_app:logout' is used
+                    # The login view for the application lives within the
+                    # ``settlements_app`` namespace.
+                    reverse('settlements_app:login'),
+                    # Allow access to the 2FA setup wizard itself.
+                    reverse('settlements_app:two_factor_setup'),
+                    # Users should always be able to log out.
+                    reverse('settlements_app:logout'),
                 ]
                 if not any(request.path.startswith(path) for path in safe_paths):
-                    return redirect('two_factor:setup')
+                    return redirect('settlements_app:two_factor_setup')
 
         return self.get_response(request)

--- a/Settlex/settings.py
+++ b/Settlex/settings.py
@@ -127,8 +127,9 @@ AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
 ]
 
-# Avoid reverse_lazy here, just use the resolved path
-LOGIN_URL = "/account/login/"
+# Use the login view defined in ``settlements_app`` for authentication
+# redirects.
+LOGIN_URL = reverse_lazy('settlements_app:login')
 LOGIN_REDIRECT_URL = reverse_lazy("settlements_app:my_settlements")
 LOGOUT_REDIRECT_URL = reverse_lazy("settlements_app:home")
 


### PR DESCRIPTION
## Summary
- fix reverse names in `Enforce2FAMiddleware`
- point `LOGIN_URL` at the login view in `settlements_app`

## Testing
- `python -m py_compile Settlex/middleware/enforce_2fa.py Settlex/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_6846380de8348329b1b5d1f81503f842