### PR TITLE
Fix TOTP device form init

### DIFF
--- a/settlements_app/tests.py
+++ b/settlements_app/tests.py
@@ -1,6 +1,9 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 from django.urls import reverse, resolve
+from django.contrib.auth import get_user_model
+from django_otp.plugins.otp_totp.models import TOTPDevice
 
+from .forms import CustomTOTPDeviceForm
 from .views import view_settlement
 
 
@@ -13,3 +16,24 @@ class URLTests(SimpleTestCase):
         self.assertEqual(url, '/settlement/1/')
         resolver = resolve('/settlement/1/')
         self.assertEqual(resolver.func, view_settlement)
+
+
+class CustomTOTPDeviceFormTests(TestCase):
+    """Ensure the TOTP setup form handles unexpected kwargs gracefully."""
+
+    def test_init_drops_unexpected_kwargs(self):
+        User = get_user_model()
+        user = User.objects.create_user(username="tester", password="pass")
+        device = TOTPDevice.objects.create(user=user, confirmed=False)
+
+        try:
+            form = CustomTOTPDeviceForm(
+                data={},
+                user=user,
+                key=device.key,
+                device=device,
+                unexpected="ignored",
+            )
+            form.is_valid()
+        except TypeError as exc:
+            self.fail(f"TypeError raised: {exc}")


### PR DESCRIPTION
## Summary
- add keyword-only init for `CustomTOTPDeviceForm`
- filter kwargs passed to the parent form
- add regression test for form initialization with unexpected kwargs

## Testing
- `python manage.py test --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_684679339e308329aa82a033c0c26d34