### PR TITLE
Ensure ValidationStepForm receives explicit args

### DIFF
--- a/settlements_app/forms.py
+++ b/settlements_app/forms.py
@@ -85,14 +85,18 @@ class WelcomeStepForm(DummyForm):
     pass
 
 class ValidationStepForm(AuthenticationTokenForm):
-    def __init__(self, *args, **kwargs):
-        self.user = kwargs.pop('user', None)
-        self.device = kwargs.pop('device', None)
-        logger.debug("🔐 ValidationStepForm initialized with user: %s and device: %s", self.user, self.device)
-        super().__init__(self.user, self.device, *args, **kwargs)
+    def __init__(self, *, user, device, **kwargs):
+        self.user = user
+        self.device = device
+        logger.debug(
+            "🔐 ValidationStepForm initialized with user: %s and device: %s",
+            self.user,
+            self.device,
+        )
+        super().__init__(user, device, **kwargs)
 
     def clean_token(self):
-        token = self.cleaned_data.get("token")
+        token = self.cleaned_data.get("otp_token")
         if not self.device:
             logger.warning("⚠️ No device assigned to ValidationStepForm.")
             raise ValidationError("Internal error: device missing.")

--- a/settlements_app/tests.py
+++ b/settlements_app/tests.py
@@ -1,7 +1,11 @@
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 from django.urls import reverse, resolve
+from django.contrib.auth import get_user_model
+from django_otp.plugins.otp_totp.models import TOTPDevice
+from django_otp.oath import TOTP
 
 from .views import view_settlement
+from .forms import ValidationStepForm
 
 
 class URLTests(SimpleTestCase):
@@ -13,3 +17,38 @@ class URLTests(SimpleTestCase):
         self.assertEqual(url, '/settlement/1/')
         resolver = resolve('/settlement/1/')
         self.assertEqual(resolver.func, view_settlement)
+
+
+class ValidationStepFormTests(TestCase):
+    """Tests for ValidationStepForm token validation."""
+
+    def setUp(self):
+        self.User = get_user_model()
+        self.user = self.User.objects.create_user(
+            username="user@example.com", password="pass"
+        )
+
+    def _create_device(self):
+        return TOTPDevice.objects.create(user=self.user, confirmed=True)
+
+    def test_valid_token(self):
+        device = self._create_device()
+        totp = TOTP(
+            bytes.fromhex(device.key),
+            device.step,
+            device.t0,
+            device.digits,
+            device.drift,
+        )
+        token = str(totp.token()).zfill(device.digits)
+
+        form = ValidationStepForm(user=self.user, device=device, data={"otp_token": token})
+        valid = form.is_valid()
+        if not valid:
+            print("form errors", form.errors)
+        self.assertTrue(valid)
+
+    def test_invalid_token(self):
+        device = self._create_device()
+        form = ValidationStepForm(user=self.user, device=device, data={"otp_token": "000000"})
+        self.assertFalse(form.is_valid())

--- a/settlements_app/views.py
+++ b/settlements_app/views.py
@@ -75,6 +75,13 @@ class SettlexTwoFactorSetupView(SetupView):
 
     template_name = 'two_factor/setup.html'
 
+    def get_form_kwargs(self, step=None):
+        kwargs = super().get_form_kwargs(step)
+        if step == 'validation':
+            kwargs['user'] = self.request.user
+            kwargs['device'] = self.get_device()
+        return kwargs
+
     def get_device(self):
         """
         Custom retrieval of the TOTPDevice using extra_data stored during the wizard.


### PR DESCRIPTION
## Summary
- refactor `ValidationStepForm.__init__` to use keyword-only arguments
- supply user and device via `get_form_kwargs`
- test token validation with explicit user/device arguments

## Testing
- `python manage.py test settlements_app.tests.ValidationStepFormTests -v 2 --debug-mode --keepdb`
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6846793585d48329b87427157c34b0ff