### PR TITLE
Fix 2FA wizard session handling

### DIFF
--- a/settlements_app/tests_two_factor.py
+++ b/settlements_app/tests_two_factor.py
@@ -45,6 +45,7 @@ class TwoFactorSetupFlowTests(TestCase):
             wizard_data['extra_data'] = extra_data
             session['settlex_two_factor_setup_view'] = wizard_data
             session.save()  # Save session after adding the device_id
+            device_id = device.id
 
         # Fetch the device and generate token
         device = TOTPDevice.objects.get(id=device_id)

--- a/settlements_app/views.py
+++ b/settlements_app/views.py
@@ -137,7 +137,8 @@ class SettlexTwoFactorSetupView(SetupView):
                 )
                 extra_data['device_id'] = device.id
                 self.storage.extra_data = extra_data
-                self.client.session['settlex_two_factor_setup_view'] = self.storage.extra_data  # Store it in session
+                # Persist wizard data to the user's session
+                self.request.session[self.storage.prefix] = self.storage.data
                 logger.debug("🛠 Created new TOTPDevice (ID: %s) with key: %s", device.id, device.key)
 
         # Ensure that the device is properly passed to the form


### PR DESCRIPTION
## Summary
- store 2FA wizard data using request session
- fix test helper to update `device_id` after creating device

## Testing
- `python manage.py test settlements_app.tests_two_factor -v 0` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6846c92a39f48329ae4cb90d4913e926