### PR TITLE
Load SECRET_KEY from env

### DIFF
--- a/.github/workflows/django-tests.yml
+++ b/.github/workflows/django-tests.yml
@@ -25,9 +25,10 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Settlex tests
-      env:
-      DJANGO_SETTINGS_MODULE: Settlex.settings
-      run: |
-      python manage.py migrate
-      python manage.py test
+        env:
+          DJANGO_SETTINGS_MODULE: Settlex.settings
+          SECRET_KEY: test-secret-key
+        run: |
+          python manage.py migrate
+          python manage.py test
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Settlex
+
+## Environment Variables
+
+- `SECRET_KEY` - Django secret key. Required for production and CI/testing environments. A development fallback key is used when this variable is not set.
+

--- a/Settlex/settings.py
+++ b/Settlex/settings.py
@@ -5,7 +5,9 @@ from datetime import datetime
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = 'django-insecure-y%h2!$!-^(2!)$dcs2bfbbnxq&)5e@%gw9!-hg%1o--e-31t3@'
+# SECRET_KEY should be provided via the environment in production.
+# A fallback value is only used during local development.
+SECRET_KEY = os.environ.get('SECRET_KEY', 'django-insecure-development-key')
 
 # Set DEBUG to False in production to avoid exposing error details
 DEBUG = True  # Changed from True for production; use True only during development

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,6 +1,7 @@
 [uwsgi]
 chdir = /home/Settlex/Settlex
 module = Settlex.wsgi:application
+env = SECRET_KEY=replace-with-production-secret
 home = /home/Settlex/.virtualenvs/settlex-env
 socket = /tmp/settlex.sock
 chmod-socket = 666


### PR DESCRIPTION
## Summary
- fetch Django `SECRET_KEY` from environment
- note `SECRET_KEY` requirement in README
- provide env var for tests
- document placeholder in `uwsgi.ini`

## Testing
- `pip install -r requirements.txt`
- `python manage.py migrate`
- `python manage.py test --verbosity 2` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_685efc97abf88329a19e2089eef38c6a