### PR TITLE
Handle adding payment direction line items

### DIFF
--- a/settlements_app/tests.py
+++ b/settlements_app/tests.py
@@ -16,7 +16,7 @@ from .views import (
     settlement_statement_word,
     payment_direction,
 )
-from .models import Firm, Solicitor, Instruction, PaymentDirection
+from .models import Firm, Solicitor, Instruction, PaymentDirection, PaymentDirectionLineItem
 
 class SendMessageTests(TestCase):
     def setUp(self):
@@ -115,7 +115,7 @@ class PaymentDirectionViewTests(TestCase):
         self.assertContains(response, 'Payment Directions')
 
     def test_post_creates_payment_direction_and_redirects(self):
-        data = {'registration_fee': '10.00', 'pexa_fee': '20.00'}
+        data = {'registration_fee': '10.00', 'pexa_fee': '20.00', 'save_main': '1'}
         response = self._call_view('post', data)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
@@ -125,6 +125,23 @@ class PaymentDirectionViewTests(TestCase):
         pd = PaymentDirection.objects.get(instruction=self.instruction)
         self.assertEqual(pd.registration_fee, Decimal('10.00'))
         self.assertEqual(pd.pexa_fee, Decimal('20.00'))
+
+    def test_add_line_item_redirects_back_to_form(self):
+        data = {
+            'save_line_item': '1',
+            'category': 'other',
+            'bank_name': 'Bank',
+            'account_name': 'Acct',
+            'account_details': '123',
+            'amount': '50.00'
+        }
+        response = self._call_view('post', data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse('settlements_app:payment_direction', args=[self.instruction.id])
+        )
+        self.assertEqual(PaymentDirectionLineItem.objects.count(), 1)
 
 
 class SettlementStatementWordTests(TestCase):

--- a/settlements_app/views.py
+++ b/settlements_app/views.py
@@ -821,12 +821,22 @@ def payment_direction(request, instruction_id):
     line_item_form = PaymentDirectionLineItemForm(request.POST or None)
 
     if request.method == 'POST':
-        if 'save_main' in request.POST or 'save_all' not in request.POST:
+        if 'save_main' in request.POST:
             # Save the main payment direction form
             if form.is_valid():
                 form.save()
                 messages.success(request, 'Payment direction saved successfully.')
                 return redirect('settlements_app:view_transaction', transaction_id=instruction.id)
+        elif 'save_line_item' in request.POST:
+            # Add a single line item
+            if line_item_form.is_valid():
+                new_item = line_item_form.save(commit=False)
+                new_item.payment_direction = payment
+                new_item.save()
+                messages.success(request, 'Payment direction line item added successfully.')
+                return redirect('settlements_app:payment_direction', instruction_id=instruction.id)
+            else:
+                messages.error(request, 'Please correct the errors below.')
         elif 'save_all' in request.POST:  # Save all lines at once
             for item in line_items:
                 # Update each line item


### PR DESCRIPTION
## Summary
- refine payment direction POST logic to distinguish between saving the form, adding a single line item, and saving all items
- expect `save_main` when persisting the main form
- add redirect and success message for new line items
- update tests for the new workflow and add coverage for adding a line item

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68670e18b9608329920007e61897c6c2