### PR TITLE
Remove duplicate Instruction model

### DIFF
--- a/settlements_app/models.py
+++ b/settlements_app/models.py
@@ -249,11 +249,3 @@ class PaymentDirectionLineItem(models.Model):
 
     def __str__(self):
         return f"{self.get_category_display()} - {self.account_name}: ${self.amount}"
-
-class Instruction(models.Model):
-    # other fields...
-    purchase_price = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    deposit = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-    adjustments = models.DecimalField(max_digits=12, decimal_places=2, null=True, blank=True)
-
-    # other fields and methods...


### PR DESCRIPTION
## Summary
- delete trailing `Instruction` model definition in `models.py`
- confirm models load and migrate successfully

## Testing
- `python manage.py makemigrations`
- `python manage.py migrate --run-syncdb`


------
https://chatgpt.com/codex/tasks/task_e_6867792027bc8329b492affa69036ab0