### PR TITLE
Add instruction email alerts and SMTP settings

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -30,3 +30,15 @@ variables. At a minimum the application expects a `SECRET_KEY` value:
 ```bash
 SECRET_KEY=your-secret-key
 ```
+
+### Email settings
+The application can send email using SMTP. Configure the following variables as needed:
+```bash
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=your.smtp.host
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_HOST_USER=your@example.com
+EMAIL_HOST_PASSWORD=your-password
+```
+`DEFAULT_FROM_EMAIL` defaults to `EMAIL_HOST_USER`.

--- a/Settlex/settings.py
+++ b/Settlex/settings.py
@@ -129,13 +129,13 @@ if not os.path.exists(MEDIA_ROOT):
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-# EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-# EMAIL_HOST = 'smtp-mail.outlook.com'
-# EMAIL_PORT = 587
-# EMAIL_USE_TLS = True
-# EMAIL_HOST_USER = 'info@onestoplegal.com.au'
-# EMAIL_HOST_PASSWORD = 'smgmbftdnrvrfgln'
-# DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
+EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend')
+EMAIL_HOST = os.getenv('EMAIL_HOST', '')
+EMAIL_PORT = int(os.getenv('EMAIL_PORT', 587))
+EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', 'True') == 'True'
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 
 # Authentication Backend

--- a/settlements_app/views.py
+++ b/settlements_app/views.py
@@ -614,6 +614,24 @@ def new_instruction(request):
                 instruction.purchaser_address = full_company_address
 
             instruction.save()
+
+            # Send summary email
+            email_subject = f"New Instruction {instruction.file_reference}"
+            email_body = (
+                f"File Reference: {instruction.file_reference}\n"
+                f"Solicitor: {solicitor.instructing_solicitor}\n"
+                f"Firm: {solicitor.firm.name if solicitor.firm else ''}\n"
+                f"Settlement Type: {instruction.settlement_type}\n"
+                f"Title Reference: {instruction.title_reference}\n"
+                f"Settlement Date: {instruction.settlement_date}"
+            )
+            send_mail(
+                subject=email_subject,
+                message=email_body,
+                from_email=settings.DEFAULT_FROM_EMAIL,
+                recipient_list=[solicitor.user.email],
+                fail_silently=False,
+            )
             logger.info(f"✅ Instruction created successfully: {instruction.file_reference}")
             messages.success(request, "Instruction created successfully!")
             return redirect('settlements_app:my_transactions')


### PR DESCRIPTION
## Summary
- email notification when creating new instructions
- support configuring SMTP via environment variables
- test posting new instruction sends email
- fix payment direction tests
- document new email environment variables

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686c3ebe7108832990421f6af3568614