### PR TITLE
Remove sensitive .env and document env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-SECRET_KEY=b2h4^pc=&hr5gjk+bj60wv4oa-+sq=67ufcm0u-qp%3^&(wuqn
-EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
-EMAIL_HOST=smtp-mail.outlook.com
-EMAIL_PORT=587
-EMAIL_USE_TLS=True
-EMAIL_HOST_USER=info@onestoplegal.com.au
-EMAIL_HOST_PASSWORD=Aussieday2017
-

--- a/README.MD
+++ b/README.MD
@@ -25,15 +25,10 @@ python manage.py test
 ```
 
 ## Environment Variables
-Create a `.env` file in the project root and define any required environment
-variables. At a minimum the application expects a `SECRET_KEY` value:
+Create a `.env` file in the project root with the following variables:
+
 ```bash
 SECRET_KEY=your-secret-key
-```
-
-### Email settings
-The application can send email using SMTP. Configure the following variables as needed:
-```bash
 EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 EMAIL_HOST=your.smtp.host
 EMAIL_PORT=587
@@ -41,4 +36,5 @@ EMAIL_USE_TLS=True
 EMAIL_HOST_USER=your@example.com
 EMAIL_HOST_PASSWORD=your-password
 ```
+
 `DEFAULT_FROM_EMAIL` defaults to `EMAIL_HOST_USER`.


### PR DESCRIPTION
## Summary
- remove `.env` from repository
- document environment variables in README

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686c6de9c4008329a8829d1455a58eb0