### PR TITLE
Fix missing websocket routes import

### DIFF
--- a/settlements_app/routing.py
+++ b/settlements_app/routing.py
@@ -1,0 +1,5 @@
+# Empty routing configuration for WebSocket connections.
+# This placeholder ensures ASGI can import websocket_urlpatterns
+# even when no WebSocket consumers are defined.
+
+websocket_urlpatterns = []


### PR DESCRIPTION
## Summary
- add `settlements_app/routing.py` with empty `websocket_urlpatterns`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_686ca7fabd648329a69fe31f0c2d8c83